### PR TITLE
Autoplay sound on edit

### DIFF
--- a/addons/gdfxr/editor/EditSlider.gd
+++ b/addons/gdfxr/editor/EditSlider.gd
@@ -2,6 +2,7 @@
 extends Control
 
 signal value_changed(value)
+signal value_submitted()
 
 @export var value: float = 0.0 :
 	set = set_value
@@ -151,6 +152,7 @@ func _drag_done() -> void:
 			(value - min_value) / (max_value - min_value),
 			0.5
 		))
+		value_submitted.emit()
 
 
 func _drag_motion(motion: InputEventMouseMotion) -> void:
@@ -201,6 +203,7 @@ func _on_line_edit_focus_exited():
 
 func _on_line_edit_text_entered(_text: String):
 	_line_edit.hide()
+	value_submitted.emit()
 
 
 func _on_line_edit_visibility_changed():

--- a/addons/gdfxr/editor/Editor.gd
+++ b/addons/gdfxr/editor/Editor.gd
@@ -69,6 +69,7 @@ func _ready():
 			_param_map[control.parameter] = control
 			control.param_changed.connect(_on_param_changed)
 			control.param_reset.connect(_on_param_reset)
+			control.param_submitted.connect(_on_param_submitted)
 	
 	_set_editing_file("")
 
@@ -246,6 +247,10 @@ func _generate_serial_path(path: String) -> String:
 	return path  # Unreachable
 
 
+func _on_param_submitted(_name):
+	_on_Play_pressed(true)
+
+
 func _on_param_changed(name, value):
 	if _syncing_ui:
 		return
@@ -270,6 +275,7 @@ func _on_param_reset(name):
 	
 	_set_modified(not _config.is_equal(_config_defaults))
 	audio_player.stream = null
+	_on_Play_pressed(true)
 
 
 func _on_Play_pressed(force_regenerate := false):
@@ -302,6 +308,7 @@ func _on_Mutate_pressed():
 
 func _on_Restore_pressed():
 	_set_editing_file(_path)
+	_on_Play_pressed(true)
 
 
 func _on_New_pressed():

--- a/addons/gdfxr/editor/ParamOption.gd
+++ b/addons/gdfxr/editor/ParamOption.gd
@@ -2,6 +2,7 @@
 extends HBoxContainer
 
 signal param_changed(name, value)
+signal param_submitted(name)
 signal param_reset(name)
 
 @export var options: Array :
@@ -38,6 +39,7 @@ func set_resetable(v: bool) -> void:
 
 func _on_OptionButton_item_selected(index: int):
 	param_changed.emit(parameter, index)
+	param_submitted.emit(parameter)
 
 
 func _on_Reset_pressed():

--- a/addons/gdfxr/editor/ParamSlider.gd
+++ b/addons/gdfxr/editor/ParamSlider.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 
 signal param_changed(name, value)
 signal param_reset(name)
+signal param_submitted(name)
 
 @export var label: String :
 	set = set_label
@@ -52,4 +53,8 @@ func _on_HSlider_value_changed(value: float):
 
 func _on_Reset_pressed():
 	param_reset.emit(parameter)
+
+
+func _on_HSlider_value_submitted():
+	param_submitted.emit(parameter)
 

--- a/addons/gdfxr/editor/ParamSlider.tscn
+++ b/addons/gdfxr/editor/ParamSlider.tscn
@@ -32,5 +32,6 @@ flat = true
 script = ExtResource("2")
 icon_name = "ReloadSmall"
 
+[connection signal="value_submitted" from="HSlider" to="." method="_on_HSlider_value_submitted"]
 [connection signal="value_changed" from="HSlider" to="." method="_on_HSlider_value_changed"]
 [connection signal="pressed" from="Reset" to="." method="_on_Reset_pressed"]


### PR DESCRIPTION
Resolves #8

This PR makes it so the editor would automatically play the sound on each completed edit (releasing slider after dragging, typing in value and hitting enter, changing waveform type, resetting individual values, restoring all values).

I concur with the issue author that a quick feedback loop would be great QoL, and while I've never used sfxr.me, the original sfxr also has similar quick feedback feature where it plays the sound when you press spacebar.

Godot plugin development is fairly new to me, so this change may need additional testing, but far as I can tell everything works fine and nothing breaks.

P.S. love this plugin!